### PR TITLE
Add a minimal E2E test for reactjs-boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 
 # env variables
 .env
+
+# e2e
+tests/e2e/utils/storageState.json

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Our roadmap for the ReactJS Boilerplate is where you can learn about what featur
     - [ ] css
     - [ ] i18n
   - [ ] E2E
-    - [ ] Playwright
+    - [x] Playwright
     - [ ] Cypress
 - Mock API server
   - [x] msw

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preview": "vite preview",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
+    "e2e": "playwright test",
     "test": "jest",
     "type": "tsc --noEmit"
   },
@@ -22,6 +23,7 @@
     "@babel/preset-env": "7.16.8",
     "@babel/preset-react": "7.16.7",
     "@babel/preset-typescript": "7.16.7",
+    "@playwright/test": "1.23.1",
     "@storybook/addon-actions": "6.5.0-alpha.16",
     "@storybook/addon-essentials": "6.5.0-alpha.16",
     "@storybook/addon-links": "6.5.0-alpha.16",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { type PlaywrightTestConfig, devices } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {
+  forbidOnly: !!process.env.CI,
+  testDir: "./tests/e2e",
+  webServer: {
+    command: "yarn dev",
+    port: 3000,
+  },
+  retries: process.env.CI ? 2 : 0,
+  globalSetup: require.resolve("./tests/e2e/utils/global-setup"),
+  use: {
+    headless: !!process.env.CI,
+    baseURL: "http://localhost:3000/",
+    // Tell all tests to load signed-in state from 'storageState.json'.
+    storageState: "./tests/e2e/utils/storageState.json",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+};
+export default config;

--- a/tests/e2e/Count.test.ts
+++ b/tests/e2e/Count.test.ts
@@ -1,0 +1,24 @@
+import { test, expect, Page } from "@playwright/test";
+
+let page: Page;
+
+test.beforeAll(async ({ browser }) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  page = await browser.newPage();
+  await page.goto("/count");
+});
+
+test.afterAll(async () => {
+  await page.close();
+});
+
+test.describe("Count page", () => {
+  test("should count up from 10 to 11", async () => {
+    // Make sure the initial count is 10
+    await expect(page.locator("span")).toHaveText(["10"]);
+    // Click the button to increase the count
+    await page.locator("button", { hasText: /^\+$/ }).click();
+    // Make sure the count now has 11
+    await expect(page.locator("span")).toHaveText(["11"]);
+  });
+});

--- a/tests/e2e/utils/global-setup.ts
+++ b/tests/e2e/utils/global-setup.ts
@@ -1,0 +1,22 @@
+import { chromium, FullConfig } from "@playwright/test";
+
+const globalSetup = async (_config: FullConfig) => {
+  const browser = await chromium.launch({ headless: !!process.env.CI });
+  const page = await browser.newPage();
+  await page.goto("http://localhost:3000/login");
+
+  await Promise.all([
+    page.waitForResponse(
+      (resp) => resp.url().includes("/api/v1/login") && resp.status() === 200
+    ),
+    page.locator("button", { hasText: /^Login$/ }).click(),
+  ]);
+
+  // Save signed-in state to 'storageState.json'.
+  await page
+    .context()
+    .storageState({ path: "./tests/e2e/utils/storageState.json" });
+  await browser.close();
+};
+
+export default globalSetup;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,6 +1616,14 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@playwright/test@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.23.1.tgz#209cceb81c579d1cd2835f15c2bb3a8345103d60"
+  integrity sha512-dKplLPSYPZgnsBk1xxOophhpx3ZVg8DveoNJgLPe096lDCfmaIIreLsYF+4hqzy3PG61IP+aEnG5VAOjC3bhbA==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.23.1"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"
@@ -9800,6 +9808,11 @@ pkg-dir@^5.0.0:
   integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
   dependencies:
     find-up "^5.0.0"
+
+playwright-core@1.23.1:
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.23.1.tgz#af02bd7568af1017e477433b1b003ba84e1eb312"
+  integrity sha512-9CXsE0gawph4KXl6oUaa0ehHRySZjHvly4TybcBXDvzK3N3o6L/eZ8Q6iVWUiMn0LLS5bRFxo1qEtOETlYJxjw==
 
 pnp-webpack-plugin@1.6.4:
   version "1.6.4"


### PR DESCRIPTION
Add a minimal E2E test.

**Reason:**
I want to use this test when merging library auto-update PRs. [refs](https://github.com/monstar-lab-oss/reactjs-boilerplate/pull/28#issuecomment-1111686728)
We can ensure a little bit of quality by running CI to merge only PRs that have been successfully tested into the main branch.

**Check:**

You can run the e2e test with the following command.

```sh
yarn e2e
```

If an error message is printed during execution, please follow the instructions printed.
(e.g. `npx playwright install`, etc.)