### PR TITLE
When updating msw, also create mock service worker

### DIFF
--- a/.github/workflows/msw_init.yml
+++ b/.github/workflows/msw_init.yml
@@ -1,13 +1,14 @@
-name: CREATING_THE_MOCK_SERVICE_WORKER
+name: Creating the mock service worker file
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
-      - "renovate/msw-**"
+      - main
     types: [opened]
 
 jobs:
-  build:
+  create_msw_file:
+    if: startsWith(github.head_ref, 'renovate/msw-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/msw_init.yml
+++ b/.github/workflows/msw_init.yml
@@ -1,0 +1,20 @@
+name: CREATING_THE_MOCK_SERVICE_WORKER
+
+on:
+  pull_request:
+    branches:
+      - "renovate/msw-**"
+    types: [opened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          npx msw init ./public
+          git add .
+          git commit -m "create service worker file"
+          git push


### PR DESCRIPTION
## Why

When the [msw version is updated](https://github.com/monstar-lab-oss/reactjs-boilerplate/pull/64), the service worker file is not updated and the test is broken.
e.g. https://github.com/monstar-lab-oss/reactjs-boilerplate/pull/84

## How

Added Github action to commit service worker file creation when `renovate/msw-**` PR is created.