### PR TITLE
Allow Dependabot to open pull requests automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## What I did

Allow Dependabot to open pull requests automatically to resolve Dependabot alerts.

I referred to the following document on how to set it up.
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

## How to test

- [ ] ~~Is this testable with jest or e2e?~~
- [ ] ~~Does this need an update to the documentation?~~

## Once this PR is merged

I would like to see if Dependabot creates a PR for a while.