### PR TITLE
Downgrade react-i18next to version to 11.18.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "7.38.0",
-    "react-i18next": "12.0.0",
+    "react-i18next": "11.18.6",
     "react-query": "3.39.2",
     "wouter": "2.8.0-alpha.2",
     "zustand": "4.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4656,10 +4656,10 @@ react-hook-form@7.38.0:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.38.0.tgz#53d6a68df587ce4ce88352f63e0ecc7fc8779320"
   integrity sha512-gxWW1kMeru9xR1GoR+Iw4hA+JBOM3SHfr4DWCUKY0xc7Vv1MLsF109oHtBeWl9shcyPFx67KHru44DheN0XY5A==
 
-react-i18next@12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-12.0.0.tgz#634015a2c035779c5736ae4c2e5c34c1659753b1"
-  integrity sha512-/O7N6aIEAl1FaWZBNvhdIo9itvF/MO/nRKr9pYqRc9LhuC1u21SlfwpiYQqvaeNSEW3g3qUXLREOWMt+gxrWbg==
+react-i18next@11.18.6:
+  version "11.18.6"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.18.6.tgz#e159c2960c718c1314f1e8fcaa282d1c8b167887"
+  integrity sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==
   dependencies:
     "@babel/runtime" "^7.14.5"
     html-parse-stringify "^3.0.1"


### PR DESCRIPTION
Related to https://github.com/monstar-lab-oss/reactjs-boilerplate/pull/179/commits/b44bca32bf1c97322fe4cb8b6f018bed30bedd5c

## What I did

Downgrade react-i18next to version 11.18.6 and it'll solve the type error.
FYI @mvn-luanvu-hn 

## How to test

- [x] Is this testable with jest or e2e?
- [ ] Does this need an update to the documentation?