### PR TITLE
Migrating to React Query 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "whatwg-fetch": "3.6.2"
   },
   "dependencies": {
+    "@tanstack/react-query": "4.16.1",
     "classnames": "2.3.2",
     "constate": "3.3.2",
     "i18next": "22.0.5",
@@ -53,7 +54,6 @@
     "react-dom": "18.2.0",
     "react-hook-form": "7.39.4",
     "react-i18next": "12.0.0",
-    "react-query": "3.39.2",
     "wouter": "2.8.1",
     "zustand": "4.1.4"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Routes } from "@/routes";
 import { AuthProvider } from "@/hooks/useAuth";
 import { CounterProvider } from "@/hooks/useCounter";

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import { useLocation } from "wouter";
 import { AuthRequest, AuthResponse } from "@/types/auth";
-import { useMutation, useQueryClient } from "react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { http } from "@/utils/http";
 import { LOCAL_STORAGE_TOKEN_KEY } from "@/constants/localStorage";
 

--- a/src/pages/EmployeeCreate.tsx
+++ b/src/pages/EmployeeCreate.tsx
@@ -1,7 +1,7 @@
 import { EmployeeForm } from "@/components/organisms/EmployeeForm";
 import { http } from "@/utils/http";
 import { Employee } from "@/types/employee";
-import { useMutation } from "react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useLocation } from "wouter";
 
 type Payload = Omit<Employee, "id">;

--- a/src/pages/EmployeeList.tsx
+++ b/src/pages/EmployeeList.tsx
@@ -4,7 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 import { Employee } from "@/types/employee";
 
 const useGetEmployeeListQuery = () =>
-  useQuery("userList", async () => await http.get<Employee[]>("/employee"));
+  useQuery({
+    queryKey: ["userList"],
+    queryFn: () => http.get<Employee[]>("/employee"),
+  });
 
 const EmployeeList = () => {
   const { isLoading, data, isFetched, isError } = useGetEmployeeListQuery();

--- a/src/pages/EmployeeList.tsx
+++ b/src/pages/EmployeeList.tsx
@@ -1,6 +1,6 @@
 import { http } from "@/utils/http";
 import { Link } from "wouter";
-import { useQuery } from "react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Employee } from "@/types/employee";
 
 const useGetEmployeeListQuery = () =>

--- a/src/pages/EmployeeUpdate.tsx
+++ b/src/pages/EmployeeUpdate.tsx
@@ -7,10 +7,10 @@ import { useLocation } from "wouter";
 type Props = { id: string };
 
 const useGetEmployeeQuery = (id: string) =>
-  useQuery(
-    ["employee", id],
-    async () => await http.get<Payload>(`/employee/${id}`)
-  );
+  useQuery({
+    queryKey: ["employee", id],
+    queryFn: () => http.get<Payload>(`/employee/${id}`),
+  });
 
 const updateEmployee = async (payload: Payload) => {
   const { id, ...body } = payload;

--- a/src/pages/EmployeeUpdate.tsx
+++ b/src/pages/EmployeeUpdate.tsx
@@ -1,7 +1,7 @@
 import { EmployeeForm } from "@/components/organisms/EmployeeForm";
 import { http } from "@/utils/http";
 import { Employee as Payload } from "@/types/employee";
-import { useMutation, useQuery } from "react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useLocation } from "wouter";
 
 type Props = { id: string };
@@ -33,7 +33,11 @@ const RemoveButton = ({ id }: { id: string }) => {
     onError: (error) => alert(error),
   });
 
-  return <button onClick={() => mutate(id)} data-testid="button-remove">Remove</button>;
+  return (
+    <button onClick={() => mutate(id)} data-testid="button-remove">
+      Remove
+    </button>
+  );
 };
 
 const EmployeeUpdate = ({ id }: Props) => {
@@ -49,7 +53,10 @@ const EmployeeUpdate = ({ id }: Props) => {
 
   return data ? (
     <>
-      <h3 style={{ display: "flex", justifyContent: "space-between" }} data-testid="employee-update-title">
+      <h3
+        style={{ display: "flex", justifyContent: "space-between" }}
+        data-testid="employee-update-title"
+      >
         {data.name} <RemoveButton id={id} />
       </h3>
       <EmployeeForm values={data} onUpdate={mutateAsync} />

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -5,7 +5,10 @@ import { http } from "@/utils/http";
 import { User } from "@/types/user";
 
 const useGetUserQuery = ({ id }: { id: string }) =>
-  useQuery("user", async () => await http.get<User>(`/user/${id}`));
+  useQuery({
+    queryKey: ["user"],
+    queryFn: () => http.get<User>(`/user/${id}`),
+  });
 
 const updateUser = async (payload: User) => {
   const response = await http.post<{ message: string }>(`/user/1`, payload);

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "react";
-import { useQuery, useMutation } from "react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { http } from "@/utils/http";
 import { User } from "@/types/user";

--- a/tests/utils/renderWithQueryClient.tsx
+++ b/tests/utils/renderWithQueryClient.tsx
@@ -1,8 +1,11 @@
-import React, { FC, ReactElement } from 'react'
-import { QueryClient, QueryClientProvider as ReactQueryClientProvider } from "react-query";
-import { RenderOptions } from '@testing-library/react'
-import { render } from '@/tests/utils'
-import '@/__mocks__/nodeServer'
+import React, { FC, ReactElement } from "react";
+import {
+  QueryClient,
+  QueryClientProvider as ReactQueryClientProvider,
+} from "react-query";
+import { RenderOptions } from "@testing-library/react";
+import { render } from "@/tests/utils";
+import "@/__mocks__/nodeServer";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -12,17 +15,19 @@ const queryClient = new QueryClient({
       retry: false,
     },
   },
- })
+});
 
-const Provider: FC<{children: React.ReactNode}> = ({children}) => {
+const Provider: FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
-    <ReactQueryClientProvider client={queryClient}>{ children }</ReactQueryClientProvider>
-  )
-}
+    <ReactQueryClientProvider client={queryClient}>
+      {children}
+    </ReactQueryClientProvider>
+  );
+};
 
 export default function renderWithQueryClient(
   ui: ReactElement,
-  options?: Omit<RenderOptions, 'wrapper'>
+  options?: Omit<RenderOptions, "wrapper">
 ) {
-  return render(ui, { wrapper: Provider, ...options })
+  return render(ui, { wrapper: Provider, ...options });
 }

--- a/tests/utils/renderWithQueryClient.tsx
+++ b/tests/utils/renderWithQueryClient.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactElement } from "react";
 import {
   QueryClient,
   QueryClientProvider as ReactQueryClientProvider,
-} from "react-query";
+} from "@tanstack/react-query";
 import { RenderOptions } from "@testing-library/react";
 import { render } from "@/tests/utils";
 import "@/__mocks__/nodeServer";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,7 +1103,7 @@
     "@babel/helper-validator-option" "^7.18.6"
     "@babel/plugin-transform-typescript" "^7.18.6"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.17.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.17.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
   integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
@@ -1563,6 +1563,19 @@
   integrity sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@tanstack/query-core@4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.15.1.tgz#a282f04fe5e612b50019e1cfaf0efabd220e00ce"
+  integrity sha512-+UfqJsNbPIVo0a9ANW0ZxtjiMfGLaaoIaL9vZeVycvmBuWywJGtSi7fgPVMCPdZQFOzMsaXaOsDtSKQD5xLRVQ==
+
+"@tanstack/react-query@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.16.1.tgz#077006b8eb2c87fbe8d1597c1a0083a2d218b791"
+  integrity sha512-PDE9u49wSDykPazlCoLFevUpceLjQ0Mm8i6038HgtTEKb/aoVnUZdlUP7C392ds3Cd75+EGlHU7qpEX06R7d9Q==
+  dependencies:
+    "@tanstack/query-core" "4.15.1"
+    use-sync-external-store "^1.2.0"
 
 "@testing-library/dom@^8.5.0":
   version "8.19.0"
@@ -2187,11 +2200,6 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-big-integer@^1.6.16:
-  version "1.6.51"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
-  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
-
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -2220,20 +2228,6 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
-
-broadcast-channel@^3.4.1:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
-  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
-  dependencies:
-    "@babel/runtime" "^7.7.2"
-    detect-node "^2.1.0"
-    js-sha3 "0.8.0"
-    microseconds "0.2.0"
-    nano-time "1.0.0"
-    oblivious-set "1.0.0"
-    rimraf "3.0.2"
-    unload "2.2.0"
 
 browserslist@^4.21.3, browserslist@^4.21.4:
   version "4.21.4"
@@ -2571,11 +2565,6 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
-
-detect-node@^2.0.4, detect-node@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
-  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 diff-sequences@^29.2.0:
   version "29.2.0"
@@ -4226,11 +4215,6 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.5.tgz#1ff1645e6b4d1b028cd3f862db88c9d887f26e2a"
   integrity sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==
 
-js-sha3@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
-  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4434,14 +4418,6 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-match-sorter@^6.0.2:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
-  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    remove-accents "0.4.2"
-
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -4459,11 +4435,6 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
-
-microseconds@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
-  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -4529,13 +4500,6 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
-
-nano-time@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
-  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
-  dependencies:
-    big-integer "^1.6.16"
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -4645,11 +4609,6 @@ object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
-
-oblivious-set@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
-  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 once@^1.3.0:
   version "1.4.0"
@@ -4947,15 +4906,6 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-query@3.39.2:
-  version "3.39.2"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.2.tgz#9224140f0296f01e9664b78ed6e4f69a0cc9216f"
-  integrity sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    broadcast-channel "^3.4.1"
-    match-sorter "^6.0.2"
-
 react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
@@ -5054,11 +5004,6 @@ regjsparser@^0.9.1:
   dependencies:
     jsesc "~0.5.0"
 
-remove-accents@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
-  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -5127,7 +5072,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@3.0.2, rimraf@^3.0.2:
+rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -5587,14 +5532,6 @@ universalify@^0.2.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
 
-unload@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
-  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    detect-node "^2.0.4"
-
 update-browserslist-db@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
@@ -5618,7 +5555,7 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-use-sync-external-store@1.2.0:
+use-sync-external-store@1.2.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==


### PR DESCRIPTION
## What I did

> If we go with react-query, the repository has changed for v4, it's @tanstack/react-query now. by @yannde

I have tested and migrated v4 and found it to be fine, please make sure your CI tests are successful.
 
## How to test

- [x] Is this testable with jest or e2e?
- [ ] Does this need an update to the documentation?

Please make sure that the CI test is successful.