### PR TITLE
Refactor CLI

### DIFF
--- a/packages/create-codes/src/helpers/degit.ts
+++ b/packages/create-codes/src/helpers/degit.ts
@@ -1,0 +1,23 @@
+import degit, { Options } from "degit";
+
+/**
+ * Copies git repository from a given reference into destination folder.
+ * Requires a source path in the following format:
+ *
+ * `{user-name}/{repository-name}/{directory-path}#{branch-name}`
+ */
+export async function cloneFromRepo(
+  src: string,
+  dest: string,
+  options: Options = {
+    cache: false,
+    force: true,
+    verbose: true,
+  }
+) {
+  await new Promise((resolve, reject) => {
+    const emitter = degit(src, options);
+    emitter.on("warn", (err) => reject(err));
+    emitter.clone(dest).then(() => resolve({}));
+  });
+}

--- a/packages/create-codes/src/helpers/prompt.ts
+++ b/packages/create-codes/src/helpers/prompt.ts
@@ -1,0 +1,170 @@
+import inquirer from "inquirer";
+import { JSLibrary, CLIOptions } from "../constants";
+
+type UserInput = {
+  jsLibrary: JSLibrary;
+  apiSolution: string;
+  modules: string[];
+  tests: {
+    useVitest: boolean | undefined;
+    useStorybook: boolean | undefined;
+    useE2E: boolean | undefined;
+    useEslint: boolean | undefined;
+    usePrettier: boolean | undefined;
+  } | null;
+};
+
+/**
+ * Prompt user for desired app directory
+ */
+export async function promptAppDir() {
+  return (
+    await inquirer.prompt<{ dir: string }>([
+      {
+        type: "input",
+        name: "dir",
+        message: "Where Would You like to Create Your Application?",
+        default: "./my-app",
+      },
+    ])
+  ).dir;
+}
+
+/**
+ * Prompt user to select app configuration
+ */
+export async function promptUserInput() {
+  // Select JS Library
+  const jsLibrary = (
+    await inquirer.prompt<{ jsLibrary: JSLibrary }>([
+      {
+        type: "list",
+        name: "jsLibrary",
+        message: "Select a JavsScript library for UI",
+        choices: (Object.keys(CLIOptions) as JSLibrary[]).map(
+          (key) => CLIOptions[key].name
+        ),
+        default: 0,
+        filter: (val: string) => val.toLowerCase().replace(/\./g, ""),
+      },
+    ])
+  ).jsLibrary;
+
+  // Select API Solution
+  const apiSolution = (
+    await inquirer.prompt<{ apiSolution: string }>([
+      {
+        type: "list",
+        name: "apiSolution",
+        message: "Select an API Solution",
+        choices: CLIOptions[jsLibrary].apiSolution,
+        default: "restful",
+      },
+    ])
+  ).apiSolution;
+
+  // Select modules for selected JS Library
+  // TODO: Use modules
+  // eslint-disable-next-line no-unused-vars
+  const modules = (
+    await inquirer.prompt<{ useModules: string[] }>([
+      {
+        type: "checkbox",
+        name: "useModules",
+        message: "Select module do you want to use",
+        choices: CLIOptions[jsLibrary].useModules,
+      },
+    ])
+  ).useModules;
+
+  // Select testing packages
+  const useTesting = (
+    await inquirer.prompt<{ useTesting: boolean }>([
+      {
+        type: "confirm",
+        name: "useTesting",
+        message: "Add Testing codes for Catching bugs early?",
+        default: true,
+      },
+    ])
+  ).useTesting;
+
+  const useVitest = (
+    await inquirer.prompt<{ useVitest?: boolean }>([
+      {
+        type: "confirm",
+        name: "useVitest",
+        message: "Add Vitest for Unit Testing?",
+        default: true,
+        when: () => useTesting,
+      },
+    ])
+  ).useVitest;
+
+  const useStorybook = (
+    await inquirer.prompt<{ useStorybook?: boolean }>([
+      {
+        type: "confirm",
+        name: "useStorybook",
+        message: "Add Storybook for Visual Testing?",
+        default: true,
+        when: () => !!useTesting,
+      },
+    ])
+  ).useStorybook;
+
+  const useE2E = (
+    await inquirer.prompt<{ useE2E?: boolean }>([
+      {
+        type: "confirm",
+        name: "useE2E",
+        message: "Add Playwright for End-To-End Testing?",
+        default: true,
+        when: () => useTesting,
+      },
+    ])
+  ).useE2E;
+
+  const useEslint = (
+    await inquirer.prompt<{ useEslint?: boolean }>([
+      {
+        type: "confirm",
+        name: "useEslint",
+        message: "Add ESLint for Code Linting?",
+        default: true,
+        when: () => useTesting,
+      },
+    ])
+  ).useEslint;
+
+  const usePrettier = (
+    await inquirer.prompt<{ usePrettier?: boolean }>([
+      {
+        type: "confirm",
+        name: "usePrettier",
+        message: "Add Prettier for Code Formatting?",
+        default: true,
+        when: () => useTesting,
+      },
+    ])
+  ).usePrettier;
+
+  const tests = !useTesting
+    ? null
+    : {
+        useVitest,
+        useStorybook,
+        useE2E,
+        useEslint,
+        usePrettier,
+      };
+
+  const userInput: UserInput = {
+    jsLibrary,
+    apiSolution,
+    modules,
+    tests,
+  };
+
+  return userInput;
+}

--- a/packages/create-codes/src/helpers/prompt.ts
+++ b/packages/create-codes/src/helpers/prompt.ts
@@ -1,17 +1,19 @@
 import inquirer from "inquirer";
 import { JSLibrary, CLIOptions } from "../constants";
 
-type UserInput = {
+export type UserInputTests = {
+  useVitest: boolean | undefined;
+  useStorybook: boolean | undefined;
+  useE2E: boolean | undefined;
+  useEslint: boolean | undefined;
+  usePrettier: boolean | undefined;
+};
+
+export type UserInput = {
   jsLibrary: JSLibrary;
   apiSolution: string;
   modules: string[];
-  tests: {
-    useVitest: boolean | undefined;
-    useStorybook: boolean | undefined;
-    useE2E: boolean | undefined;
-    useEslint: boolean | undefined;
-    usePrettier: boolean | undefined;
-  } | null;
+  tests: UserInputTests | null;
 };
 
 /**

--- a/packages/create-codes/src/index.ts
+++ b/packages/create-codes/src/index.ts
@@ -76,6 +76,23 @@ function copyBase(
   return packageObjs;
 }
 
+/**
+ * Copy the selected modules into the target app directory.
+ */
+function copyModules(appDir: string, apiSolution: string, useTests: boolean) {
+  // TODO: Copy modules (currently only copying the API solution)
+  fse.copySync(
+    path.resolve(TEMP_DIR, `module-api-${apiSolution}`),
+    path.resolve(appDir, "src/modules"),
+    {
+      filter: (src) => {
+        if (!useTests && /$(?<=\.test\.(ts|tsx))/.test(src)) return false;
+        return !EXCLUDE.includes(path.basename(src));
+      },
+    }
+  );
+}
+
 async function run() {
   const { input } = meow(help, {
     flags: {
@@ -103,17 +120,8 @@ async function run() {
   const configDir = path.resolve(CONFIG_TEMPLATES, jsLibrary);
   const sharedConfigDir = path.resolve(CONFIG_TEMPLATES, "__shared");
 
-  // TODO: Copy modules
-  fse.copySync(
-    path.resolve(TEMP_DIR, `module-api-${apiSolution}`),
-    path.resolve(appDir, "src/modules"),
-    {
-      filter: (src) => {
-        if (tests === null && /$(?<=\.test\.(ts|tsx))/.test(src)) return false;
-        return !EXCLUDE.includes(path.basename(src));
-      },
-    }
-  );
+  // Copy modules
+  copyModules(appDir, apiSolution, tests !== null);
 
   // Copy testing libraries
   if (tests?.useVitest) {

--- a/packages/create-codes/src/index.ts
+++ b/packages/create-codes/src/index.ts
@@ -174,19 +174,6 @@ async function copyTests(
     packageObjs = deepMergeObjects(packageObjs, fse.readJsonSync(packages));
   }
 
-  // FIXME: temporary processing, It would be good to refer to it from package.json under cli templates as well as others.
-  if (!tests.useEslint) {
-    // TODO: copy .eslintignore from base
-    // fse.removeSync(path.resolve(appDir, ".eslintrc.js"));
-    //@ts-expect-error
-    delete packageObjs.scripts.lint;
-    //@ts-expect-error
-    Object.keys(packageObjs.devDependencies).forEach((key) => {
-      //@ts-expect-error
-      eslintPackages.includes(key) && delete packageObjs.devDependencies[key];
-    });
-  }
-
   if (tests.usePrettier) {
     const sourceDir = path.resolve(sharedConfigDir, "prettier");
     const packages = path.join(sourceDir, "package.json");
@@ -227,6 +214,21 @@ function copyCommon(
   });
 }
 
+/**
+ * Remove ESLint-related config from output project files.
+ */
+function removeEslintConfig() {
+  // TODO: copy .eslintignore from base
+  // fse.removeSync(path.resolve(appDir, ".eslintrc.js"));
+  //@ts-expect-error
+  delete packageObjs.scripts.lint;
+  //@ts-expect-error
+  Object.keys(packageObjs.devDependencies).forEach((key) => {
+    //@ts-expect-error
+    eslintPackages.includes(key) && delete packageObjs.devDependencies[key];
+  });
+}
+
 async function run() {
   const { input } = meow(help, {
     flags: {
@@ -264,6 +266,11 @@ async function run() {
       sharedConfigDir,
       packageObjs
     );
+  }
+
+  // FIXME: temporary processing, It would be good to refer to it from package.json under cli templates as well as others.
+  if (!tests?.useEslint) {
+    removeEslintConfig();
   }
 
   // Copy commons

--- a/packages/create-codes/src/index.ts
+++ b/packages/create-codes/src/index.ts
@@ -201,6 +201,32 @@ async function copyTests(
   return packageObjs;
 }
 
+/**
+ * Copy common files into the target app directory
+ */
+function copyCommon(
+  appDir: string,
+  sharedConfigDir: string,
+  packageObjs: Record<string, unknown>
+) {
+  fse.copySync(`${sharedConfigDir}/gitignore`, `${appDir}/gitignore`);
+  // FIXME: reuse codes with internal package
+  fse.copySync(`${sharedConfigDir}/__mocks__`, `${appDir}/__mocks__`, {
+    overwrite: true,
+  });
+  // Rename dot files
+  fse.renameSync(
+    path.join(appDir, "gitignore"),
+    path.join(appDir, ".gitignore")
+  );
+
+  // Rewrite package.json
+  fse.writeJsonSync(path.join(appDir, "package.json"), packageObjs, {
+    spaces: 2,
+    EOL: os.EOL,
+  });
+}
+
 async function run() {
   const { input } = meow(help, {
     flags: {
@@ -241,22 +267,7 @@ async function run() {
   }
 
   // Copy commons
-  fse.copySync(`${sharedConfigDir}/gitignore`, `${appDir}/gitignore`);
-  // FIXME: reuse codes with internal package
-  fse.copySync(`${sharedConfigDir}/__mocks__`, `${appDir}/__mocks__`, {
-    overwrite: true,
-  });
-  // Rename dot files
-  fse.renameSync(
-    path.join(appDir, "gitignore"),
-    path.join(appDir, ".gitignore")
-  );
-
-  // Rewrite package.json
-  fse.writeJsonSync(path.join(appDir, "package.json"), packageObjs, {
-    spaces: 2,
-    EOL: os.EOL,
-  });
+  copyCommon(appDir, sharedConfigDir, packageObjs);
 
   console.log();
   console.log(`Success! Created a new app at "${path.basename(appDir)}".`);


### PR DESCRIPTION
Resolves #730 

## What I did
Refactored `create-codes/src/index.ts` by extracting certain processes into functions. 
I was contemplating on moving the `copy***()` functions to a separate file, but I've decided to keep them in `index.ts` for now, due to the shared usage of [packageObj](https://github.com/monstar-lab-oss/reactjs-boilerplate/compare/react-base...chore/refactor-cli?expand=1#diff-99a753364631a6b146ec54a20992111161cbb8867b4a612773bb1e41d6be0b0bR36). 

※ I think there are still many places to refactor and improve, but due to the scope and time limit of this issue, I've decided to stop here. If there is any improvement that you feel should be added to this PR, please feel free to comment!

## How to test

- [x] Is this testable with jest or e2e?
- [ ] Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
